### PR TITLE
Leave no apk cache in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build
 FROM golang:1.21.0-alpine AS builder
-RUN apk add build-base libpcap-dev
+RUN apk add --no-cache build-base libpcap-dev
 WORKDIR /app
 COPY . /app
 WORKDIR /app/v2
@@ -9,6 +9,6 @@ RUN go build ./cmd/naabu
 
 # Release
 FROM alpine:3.18.3
-RUN apk add nmap libpcap-dev bind-tools ca-certificates nmap-scripts
+RUN apk add --no-cache nmap libpcap-dev bind-tools ca-certificates nmap-scripts
 COPY --from=builder /app/v2/naabu /usr/local/bin/
 ENTRYPOINT ["naabu"]


### PR DESCRIPTION
Use `apk add` with `--no-cache` will prevent leaving cache in the released image, and it's now kind of Dockerfile best practice.